### PR TITLE
stop-looping-on-eof

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -10,7 +10,7 @@ SET changeInterval=%2
     GOTO completed
 )
 
-powershell -executionpolicy remotesigned -File ./build.ps1 -currentValuesPath %currentValuesPath% -changeInterval %changeInterval%
+powershell -executionpolicy bypass -File ./build.ps1 -currentValuesPath %currentValuesPath% -changeInterval %changeInterval%
 exit /b %errorlevel%
 
 :completed

--- a/build.ps1
+++ b/build.ps1
@@ -23,7 +23,7 @@ $sourceDirectory="$rootDirectory\src"
 $deploymentDirectory="$rootDirectory\deployment"
 
 Write-Host "Cleaning build artifacts" -ForegroundColor Green
-Remove-Item $deploymentDirectory -Force -Recurse -ErrorAction Continue
+Remove-Item $deploymentDirectory -Force -Recurse -ErrorAction SilentlyContinue
 
 New-Item -Path $deploymentDirectory -ItemType Directory -Force -ErrorAction Continue | Out-Null
 Write-Host "Finished cleaning build artifacts" -ForegroundColor Green

--- a/build.ps1
+++ b/build.ps1
@@ -29,10 +29,11 @@ New-Item -Path $deploymentDirectory -ItemType Directory -Force -ErrorAction Cont
 Write-Host "Finished cleaning build artifacts" -ForegroundColor Green
 
 $currentValues=Get-Current-Values $currentValuesPath
-Write-Host "Values read from csv:$currentValues"
-Copy-Item "$sourceDirectory\automaticCurrentControl.template.ino" "$deploymentDirectory\automaticCurrentControl.ino" -Force
+$valuesCount=($currentValues -split ",").Count
+Write-Host "Values ($valuesCount) read from csv:$currentValues"
+Copy-Item "$sourceDirectory\automaticCurrentControl.template" "$deploymentDirectory\automaticCurrentControl.ino" -Force
 
-(Get-Content "$deploymentDirectory\automaticCurrentControl.ino").replace('{{CurrentValues}}', "{$currentValues}").replace('{{intervalInSeconds}}',"$changeInterval") | Set-Content "$deploymentDirectory\automaticCurrentControl.ino"
+(Get-Content "$deploymentDirectory\automaticCurrentControl.ino").replace('{{CurrentValues}}', "{$currentValues}").replace('{{IntervalInSeconds}}',"$changeInterval").replace('{{ValuesCount}}',"$valuesCount") | Set-Content "$deploymentDirectory\automaticCurrentControl.ino"
 Write-Host "Finished replacing placeholders" -ForegroundColor Green
 
 Write-Host "Build script finished"

--- a/src/automaticCurrentControl.template
+++ b/src/automaticCurrentControl.template
@@ -1,6 +1,7 @@
 float currentValues[]={{CurrentValues}};
 int currentBinaryValue[12];//MSB->LSB
-int intervalInSeconds={{intervalInSeconds}};
+int intervalInSeconds={{IntervalInSeconds}};
+int valuesCount={{ValuesCount}}
 int valueIndex=0;
 float resolution=0.025;
 
@@ -21,10 +22,12 @@ void setup() {
 }
 
 void loop() {
-  setCurrentValue(valueIndex);
+  if(valueIndex < valuesCount){
+    setCurrentValue(valueIndex);
 
-  delay(intervalInSeconds*1000);
-  valueIndex++; 
+    delay(intervalInSeconds * 1000);
+    valueIndex++;   
+  }  
 }
 
 void setCurrentValue(int valueIndex){


### PR DESCRIPTION
Fix execution policy and minor style changes.
Silently continue on missing build artifacts folder.

Should be able to run this on any computer no matter the execution policy.